### PR TITLE
When using an assumed role the author is set to null when pushing code via cli

### DIFF
--- a/source/lambda/event_parser/codecommit_events.js
+++ b/source/lambda/event_parser/codecommit_events.js
@@ -36,7 +36,12 @@ let TransformCodeCommitEvents = (data, recordNumber) => {
       //process commits made from command line git commands
       if (detailData.hasOwnProperty('userIdentity') && detailData['userIdentity'] != null) {
         let userIdentity = detailData['userIdentity'];
-        if (userIdentity['userName'] != null) transformedDetail['authorName'] = userIdentity['userName'];
+        if (userIdentity['userName'] != null) 
+          transformedDetail['authorName'] = userIdentity['userName'];
+        else
+          //process author from codecommit with assumed role credentials
+          if (userIdentity['principalId'] != null) 
+            transformedDetail["authorName"] = userIdentity["principalId"].split(':')[1];
       }
 
       //process commits made from aws codecommit console


### PR DESCRIPTION
**How to Replicate**: Create a repository that is monitored by the solution and use Cloud9 with default settings to push code. Open the quick sight dashboard Code Change Tab and check the commit author is set to Null. 
 
**Details**
The event is different when a user pushes code using federation, it does not capture the user name and it uses the principal Id (Line 5)
That happens regardless if the author is configured on git because that information is not passed through the eventbridge event.

```
    "detail": {
        "eventVersion": "1.08",
        "userIdentity": {
            "type": "AssumedRole",
            "principalId": "AROAR4LH6OTFOYEXONP77:bontorin-Isengard",
            "arn": "arn:aws:sts::129603892426:assumed-role/Admin-OneClick/bontorin-Isengard",
            "accountId": "129603892426",
            "accessKeyId": "ASIAR4LH6OTFD2CYIFWL",
            "sessionContext": {
                "sessionIssuer": {
                    "type": "Role",
                    "principalId": "AROAR4LH6OTFOYEXONP77",
                    "arn": "arn:aws:iam::129603892426:role/Admin-OneClick",
                    "accountId": "129603892426",
                    "userName": "Admin-OneClick"
                },
                "webIdFederationData": {},
                "attributes": {
                    "creationDate": "2022-11-18T22:26:21Z",
                    "mfaAuthenticated": "false"
                }
            }
        },
        "eventTime": "2022-11-18T22:45:50Z",
        "eventSource": "codecommit.amazonaws.com",
        "eventName": "GitPush",
        "awsRegion": "us-east-1",
        "sourceIPAddress": "3.239.0.81",
        "userAgent": "git/2.37.1",
        "requestParameters": {
            "references": [
                {
                    "commit": "07f8a869121b4d238d1ecbec74d1d14a24d0576a",
                    "ref": "refs/heads/dev"
                }
            ]
        },
```

Screenshot

![quicksight-null-author](https://user-images.githubusercontent.com/3011953/204875270-f43c0157-6252-4808-9d22-06c7d0fdbe9a.png)




